### PR TITLE
Feature: Fallback to default application if none is specified

### DIFF
--- a/lib/strategy/EnrichClientFromRemoteConfigStrategy.js
+++ b/lib/strategy/EnrichClientFromRemoteConfigStrategy.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _ = require('lodash');
+
 /**
  * Retrieves Stormpath settings from the API service, and ensures the local
  * configuration object properly reflects these settings.
@@ -15,6 +17,7 @@ function EnrichClientFromRemoteConfigStrategy (clientFactory) {
 EnrichClientFromRemoteConfigStrategy.prototype._resolveApplicationByHref = function (client, config, href, cb) {
   client.getApplication(href, function (err, app) {
     if (err) {
+      // TODO: If 404 then give the user a more valuable error, e.g. stating that the application doesn't exist.
       cb(err);
     } else {
       config.application = app;
@@ -26,14 +29,14 @@ EnrichClientFromRemoteConfigStrategy.prototype._resolveApplicationByHref = funct
 // Finds and returns an Application object given an Application name.  Will
 // return an error if no Application is found.
 EnrichClientFromRemoteConfigStrategy.prototype._resolveApplicationByName = function (client, config, name, cb) {
-  client.getApplications({ name: name }, function(err, applications) {
+  client.getApplications({ name: name }, function (err, applications) {
     if (err) {
       return cb(err);
     }
 
-    applications.detect(function(app, cb) {
+    applications.detect(function (app, cb) {
       cb(name === app.name);
-    }, function(app) {
+    }, function (app) {
       if (!app) {
         cb(new Error('Application not found: "' + name + '"'));
       } else {
@@ -44,35 +47,50 @@ EnrichClientFromRemoteConfigStrategy.prototype._resolveApplicationByName = funct
   });
 };
 
-EnrichClientFromRemoteConfigStrategy.prototype.process = function (config, callback) {
-  var application = config.application;
+// If there are only two applications and one of them is
+// the Stormpath application, then use the other one as default.
+EnrichClientFromRemoteConfigStrategy.prototype._resolveDefaultApplication = function (client, config, cb) {
+  client.getApplications(function (err, applications) {
+    if (err) {
+      return cb(err);
+    }
 
+    var userApplications = _.filter(applications.items, function (app) {
+      return app.name !== 'Stormpath';
+    });
+
+    if (userApplications.length === 1) {
+      config.application = userApplications[0];
+      cb(null, userApplications[0]);
+    } else {
+      cb(new Error('No application found.'));
+    }
+  });
+};
+
+EnrichClientFromRemoteConfigStrategy.prototype.process = function (config, callback) {
   if (config.skipRemoteConfig) {
     return callback(null, config);
   }
 
-  // If we have an application then resolve a configuration using it.
-  if (application) {
-    var resolver = null;
-    var client = this.clientFactory(config);
+  var resolver = null;
+  var application = config.application || {};
+  var client = this.clientFactory(config);
 
-    // Resolve the application either explicitly by HREF or implicitly by name.
-    if (application.href) {
-      resolver = this._resolveApplicationByHref.bind(this, client, config, application.href);
-    } else if (application.name) {
-      resolver = this._resolveApplicationByName.bind(this, client, config, application.name);
-    }
-
-    if (resolver) {
-      return client.on('ready', function () {
-        resolver(function (err) {
-          callback(err, err ? null : config);
-        });
-      });
-    }
+  // Resolve the application either explicitly by HREF or implicitly by name.
+  if (application.href) {
+    resolver = this._resolveApplicationByHref.bind(this, client, config, application.href);
+  } else if (application.name) {
+    resolver = this._resolveApplicationByName.bind(this, client, config, application.name);
+  } else {
+    resolver = this._resolveDefaultApplication.bind(this, client, config);
   }
 
-  callback(null, config);
+  client.on('ready', function () {
+    resolver(function (err) {
+      callback(err, err ? null : config);
+    });
+  });
 };
 
 module.exports = EnrichClientFromRemoteConfigStrategy;

--- a/lib/strategy/EnrichClientFromRemoteConfigStrategy.js
+++ b/lib/strategy/EnrichClientFromRemoteConfigStrategy.js
@@ -17,8 +17,14 @@ function EnrichClientFromRemoteConfigStrategy (clientFactory) {
 EnrichClientFromRemoteConfigStrategy.prototype._resolveApplicationByHref = function (client, config, href, cb) {
   client.getApplication(href, function (err, app) {
     if (err) {
-      // TODO: If 404 then give the user a more valuable error, e.g. stating that the application doesn't exist.
-      cb(err);
+      if(err.status === 404){
+        cb(new Error(
+          'The provided application could not be found.\n\n' +
+          'The provided application href was: ' + href + '\n'
+        ));
+      }else{
+        cb(err);
+      }
     } else {
       config.application = app;
       cb(null, app);
@@ -38,7 +44,10 @@ EnrichClientFromRemoteConfigStrategy.prototype._resolveApplicationByName = funct
       cb(name === app.name);
     }, function (app) {
       if (!app) {
-        cb(new Error('Application not found: "' + name + '"'));
+        cb(new Error(
+          'The provided application could not be found.\n\n' +
+          'The provided application name was: ' + name + '\n'
+        ));
       } else {
         config.application = app;
         cb(null, app);
@@ -63,7 +72,10 @@ EnrichClientFromRemoteConfigStrategy.prototype._resolveDefaultApplication = func
       config.application = userApplications[0];
       cb(null, userApplications[0]);
     } else {
-      cb(new Error('No application found.'));
+      cb(new Error(
+        'Could not automatically resolve a Stormpath Application.  \n\n'+
+        'Please specify your Stormpath Application in your configuration.\n'
+      ));
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "istanbul": "^0.4.0",
     "mocha": "^2.3.3",
     "mocha-lcov-reporter": "^1.0.0",
+    "sinon": "^1.17.2",
+    "stormpath": "^0.13.4",
     "temp": "^0.8.3"
   },
   "dependencies": {

--- a/test/common.js
+++ b/test/common.js
@@ -1,12 +1,15 @@
+var _ = require('lodash');
 var temp = require('temp');
 var chai = require('chai');
+var sinon = require('sinon');
 
 // Automatically clean up temp
 // files after tests complete.
 temp.track();
 
 module.exports = {
-  _: require('lodash'),
+  _: _,
   assert: chai.assert,
+  sinon: sinon,
   temp: temp
 };

--- a/test/strategy/EnrichClientFromRemoteConfigStrategyTest.js
+++ b/test/strategy/EnrichClientFromRemoteConfigStrategyTest.js
@@ -1,0 +1,137 @@
+'use strict';
+
+var stormpath = require('stormpath');
+
+var common = require('../common');
+var _ = common._;
+var assert = common.assert;
+var sinon = common.sinon;
+
+var strategy = require('../../lib/strategy');
+var EnrichClientFromRemoteConfigStrategy = strategy.EnrichClientFromRemoteConfigStrategy;
+
+describe('EnrichClientFromRemoteConfigStrategy', function () {
+  var client, mockApplications, testStrategy;
+
+  before(function (done) {
+    mockApplications = [{
+      href: 'https://stormpath.mock/applications/stormpath',
+      name: 'Stormpath'
+    }, {
+      href: 'https://stormpath.mock/applications/my-application',
+      name: 'My Application'
+    }];
+
+    client = new stormpath.Client({
+      skipRemoteConfig: true
+    });
+
+    testStrategy = new EnrichClientFromRemoteConfigStrategy(function () {
+      return client;
+    });
+
+    client.on('error', function (err) {
+      throw err;
+    });
+
+    client.on('ready', function () {
+      done();
+    });
+  });
+
+  it('should resolve application by name', function (done) {
+    var mockApplication = mockApplications[1];
+    var mockName = mockApplication.name;
+
+    var testConfig = {
+      application: {
+        name: mockName
+      }
+    };
+
+    if (client.getApplications.restore) {
+      client.getApplications.restore();
+    }
+
+    var mockItems = {
+      items: mockApplications
+    };
+
+    mockItems.detect = function (predicate, callback) {
+      predicate(mockApplications[0], function (result) {
+        assert.isFalse(result);
+      });
+      predicate(mockApplication, function (result) {
+        assert.isTrue(result);
+      });
+      callback(mockApplication);
+    };
+
+    sinon.stub(client, 'getApplications')
+      .withArgs({ name: mockName })
+      .yields(null, mockItems);
+
+    testStrategy.process(testConfig, function (err, resultConfig) {
+      assert.isNull(err);
+
+      assert.deepEqual(resultConfig, {
+        application: mockApplication
+      });
+
+      done();
+    });
+  });
+
+  it('should resolve application by href', function (done) {
+    var mockApplication = mockApplications[1];
+    var mockHref = mockApplication.href;
+
+    var testConfig = {
+      application: {
+        href: mockHref
+      }
+    };
+
+    if (client.getApplication.restore) {
+      client.getApplication.restore();
+    }
+
+    sinon.stub(client, 'getApplication')
+      .withArgs(mockHref)
+      .yields(null, mockApplication);
+
+    testStrategy.process(testConfig, function (err, resultConfig) {
+      assert.isNull(err);
+
+      assert.deepEqual(resultConfig, {
+        application: mockApplication
+      });
+
+      done();
+    });
+  });
+
+  describe('when neither href or name is specified', function () {
+    it('should resolve a default application', function (done) {
+      var testConfig = {};
+
+      if (client.getApplications.restore) {
+        client.getApplications.restore();
+      }
+
+      sinon.stub(client, 'getApplications').yields(null, {
+        items: mockApplications
+      });
+
+      testStrategy.process(testConfig, function (err, resultConfig) {
+        assert.isNull(err);
+
+        assert.deepEqual(resultConfig, {
+          application: mockApplications[1]
+        });
+
+        done();
+      });
+    });
+  });
+});

--- a/test/strategy/EnrichClientFromRemoteConfigStrategyTest.js
+++ b/test/strategy/EnrichClientFromRemoteConfigStrategyTest.js
@@ -3,24 +3,54 @@
 var stormpath = require('stormpath');
 
 var common = require('../common');
-var _ = common._;
 var assert = common.assert;
 var sinon = common.sinon;
+
+var Application = require('stormpath/lib/resource/Application');
+var Collection = require('stormpath/lib/resource/CollectionResource');
 
 var strategy = require('../../lib/strategy');
 var EnrichClientFromRemoteConfigStrategy = strategy.EnrichClientFromRemoteConfigStrategy;
 
 describe('EnrichClientFromRemoteConfigStrategy', function () {
-  var client, mockApplications, testStrategy;
+  var client, testStrategy;
+
+  var applicationNotFoundError = /The provided application could not be found/;
+
+  var unresolveableCollectionError = /Could not automatically resolve a Stormpath Application/;
+
+  var mockApplicationNotFoundResponse = {
+    status: 404
+  };
+
+  var mockRestApiError = {
+    err: 'something bad happened'
+  };
+
+  var mockApplications = [{
+    href: 'https://stormpath.mock/applications/stormpath',
+    name: 'Stormpath'
+  }, {
+    href: 'https://stormpath.mock/applications/my-application',
+    name: 'My Application'
+  }];
+
+  var mockEmptyCollectionResponse = new Collection({
+    items: []
+  });
+
+  var mockResolveableApplicationResponse = new Collection({
+    items: mockApplications
+  });
+
+  var mockUnresolveableApplicationResponse = new Collection({
+    items: mockApplications.concat([{
+      href: 'https://stormpath.mock/applications/my-other-application',
+      name: 'My Other Application'
+    }])
+  });
 
   before(function (done) {
-    mockApplications = [{
-      href: 'https://stormpath.mock/applications/stormpath',
-      name: 'Stormpath'
-    }, {
-      href: 'https://stormpath.mock/applications/my-application',
-      name: 'My Application'
-    }];
 
     client = new stormpath.Client({
       skipRemoteConfig: true
@@ -39,50 +69,73 @@ describe('EnrichClientFromRemoteConfigStrategy', function () {
     });
   });
 
-  it('should resolve application by name', function (done) {
-    var mockApplication = mockApplications[1];
-    var mockName = mockApplication.name;
+  describe('when an application name is specified', function(){
 
-    var testConfig = {
-      application: {
-        name: mockName
-      }
-    };
-
-    if (client.getApplications.restore) {
+    afterEach(function(){
       client.getApplications.restore();
-    }
-
-    var mockItems = {
-      items: mockApplications
-    };
-
-    mockItems.detect = function (predicate, callback) {
-      predicate(mockApplications[0], function (result) {
-        assert.isFalse(result);
-      });
-      predicate(mockApplication, function (result) {
-        assert.isTrue(result);
-      });
-      callback(mockApplication);
-    };
-
-    sinon.stub(client, 'getApplications')
-      .withArgs({ name: mockName })
-      .yields(null, mockItems);
-
-    testStrategy.process(testConfig, function (err, resultConfig) {
-      assert.isNull(err);
-
-      assert.deepEqual(resultConfig, {
-        application: mockApplication
-      });
-
-      done();
     });
+
+    it('should return REST API errors if the erorr is not 404', function(done) {
+
+      var testConfig = {
+        application: {
+          name: 'hello'
+        }
+      };
+
+      sinon.stub(client, 'getApplications').yields(mockRestApiError);
+
+      testStrategy.process(testConfig, function (err) {
+        assert.isNotNull(err);
+        assert.deepEqual(err,mockRestApiError);
+        done();
+      });
+    });
+
+    it('should return an error if the application cannot be found', function(done) {
+      var mockName = 'hello';
+
+      var testConfig = {
+        application: {
+          name: mockName
+        }
+      };
+
+      sinon.stub(client, 'getApplications')
+        .withArgs({ name: mockName })
+        .yields(null, mockEmptyCollectionResponse);
+
+      testStrategy.process(testConfig, function (err) {
+        assert.isNotNull(err);
+        assert.match(err.message,applicationNotFoundError);
+        done();
+      });
+    });
+
+    it('should return the correct application if it exists', function (done) {
+      var mockApplication = mockApplications[1];
+      var mockName = mockApplication.name;
+
+      var testConfig = {
+        application: {
+          name: mockName
+        }
+      };
+
+      sinon.stub(client, 'getApplications')
+        .withArgs({ name: mockName })
+        .yields(null, mockResolveableApplicationResponse);
+
+      testStrategy.process(testConfig, function (err, resultConfig) {
+        assert.isNull(err);
+        assert.equal(resultConfig.application.name, mockApplication.name);
+        done();
+      });
+    });
+
   });
 
-  it('should resolve application by href', function (done) {
+  describe('when an application href is defined', function(){
     var mockApplication = mockApplications[1];
     var mockHref = mockApplication.href;
 
@@ -92,44 +145,92 @@ describe('EnrichClientFromRemoteConfigStrategy', function () {
       }
     };
 
-    if (client.getApplication.restore) {
+    afterEach(function(){
       client.getApplication.restore();
-    }
+    });
 
-    sinon.stub(client, 'getApplication')
-      .withArgs(mockHref)
-      .yields(null, mockApplication);
+    it('should return REST API errors if the erorr is not 404', function(done) {
 
-    testStrategy.process(testConfig, function (err, resultConfig) {
-      assert.isNull(err);
+      sinon.stub(client, 'getApplication')
+        .withArgs(mockHref)
+        .yields(mockRestApiError);
 
-      assert.deepEqual(resultConfig, {
-        application: mockApplication
+      testStrategy.process(testConfig, function (err) {
+        assert.isNotNull(err);
+        assert.deepEqual(err,mockRestApiError);
+        done();
       });
 
-      done();
+    });
+
+    it('should return an error if the application cannot be found by href', function(done) {
+
+      sinon.stub(client, 'getApplication')
+        .withArgs(mockHref)
+        .yields(mockApplicationNotFoundResponse);
+
+      testStrategy.process(testConfig, function (err) {
+        assert.isNotNull(err);
+        assert.match(err.message,applicationNotFoundError);
+        done();
+      });
+
+    });
+
+    it('should resolve application by href if the application exists', function (done) {
+
+      sinon.stub(client, 'getApplication')
+        .withArgs(mockHref)
+        .yields(null, new Application(mockApplication));
+
+      testStrategy.process(testConfig, function (err, resultConfig) {
+        assert.isNull(err);
+        assert.equal(resultConfig.application.href, mockApplication.href);
+        done();
+      });
+
     });
   });
 
   describe('when neither href or name is specified', function () {
-    it('should resolve a default application', function (done) {
-      var testConfig = {};
 
-      if (client.getApplications.restore) {
-        client.getApplications.restore();
-      }
+    var testConfig = {};
 
-      sinon.stub(client, 'getApplications').yields(null, {
-        items: mockApplications
+    afterEach(function(){
+      client.getApplications.restore();
+    });
+
+    it('should return REST API errors if the erorr is not 404', function(done) {
+
+      sinon.stub(client, 'getApplications').yields(mockRestApiError);
+
+      testStrategy.process(testConfig, function (err) {
+        assert.isNotNull(err);
+        assert.deepEqual(err,mockRestApiError);
+        done();
       });
+    });
+
+    it('should return an "unresolveable" error if more than one application exists, other than the `Stormpath` application', function(done) {
+
+      sinon.stub(client, 'getApplications')
+        .yields(null, mockUnresolveableApplicationResponse);
+
+      testStrategy.process(testConfig, function (err) {
+        assert.isNotNull(err);
+        assert.match(err.message,unresolveableCollectionError);
+        done();
+      });
+    });
+
+    it('should return the application that is not the `Stormpath` application, if that is the only other application that exists', function (done) {
+
+      sinon.stub(client, 'getApplications')
+        .yields(null, mockResolveableApplicationResponse);
 
       testStrategy.process(testConfig, function (err, resultConfig) {
         assert.isNull(err);
-
-        assert.deepEqual(resultConfig, {
-          application: mockApplications[1]
-        });
-
+        assert.equal(resultConfig.application.href, mockApplications[1].href);
         done();
       });
     });


### PR DESCRIPTION
Fixes so that when resolving an application, if neither href or name is specified, and the application only has one other application (non Stormpath), it defaults to that application.

Closes https://github.com/stormpath/express-stormpath/issues/181