### PR TITLE
Callback bugs

### DIFF
--- a/lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js
+++ b/lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js
@@ -120,10 +120,10 @@ EnrichIntegrationFromRemoteConfigStrategy.prototype._resolveDirectoryHref = func
             return callback(err, group && group.directory.href);
           });
         } else {
-          return callback();
+          return callback(null, null);
         }
       } else {
-        return callback();
+        return callback(null, null);
       }
     });
   });
@@ -133,7 +133,7 @@ EnrichIntegrationFromRemoteConfigStrategy.prototype._resolveDirectoryHref = func
 // and applies them to the local configuration.
 EnrichIntegrationFromRemoteConfigStrategy.prototype._enrichWithDirectoryPolicies = function (client, config, directoryHref, callback) {
   if (!directoryHref) {
-    return callback();
+    return callback(null, null);
   }
 
   // Helper method that checks if a status is set to "enabled".
@@ -177,7 +177,7 @@ EnrichIntegrationFromRemoteConfigStrategy.prototype._enrichWithDirectoryPolicies
 
         config.passwordPolicy = strength;
 
-        callback();
+        callback(null, null);
       }));
     }));
   }));

--- a/lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js
+++ b/lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js
@@ -105,8 +105,8 @@ EnrichIntegrationFromRemoteConfigStrategy.prototype._resolveDirectoryHref = func
       return callback(err);
     }
 
-    mappings.detect(function(mapping, callback) {
-      callback(mapping.isDefaultAccountStore);
+    mappings.detect(function(mapping, detectCallback) {
+      detectCallback(mapping.isDefaultAccountStore);
     }, function(defaultMapping) {
       if (defaultMapping) {
         var href = defaultMapping.accountStore.href;


### PR DESCRIPTION
I got an error saying `callback is not a function` whenever I used the `express-stormpath` library with my account. The reason seemed to be that I didn't have any default mapping (Account Store Mapping) and the callback on line 126 was invoked like this: `callback();`. That made the next callback land on the wrong argument for the next function in the waterfall (`_enrichWithDirectoryPolicies`).

## Includes

* Callbacks from `async.waterfall` should never be invoked without any arguments
 
  They're being bound to other arguments on line 197 to 201, so when invoking without arguments, the next function in the waterfall will be without these arguments, and the `callback` variable will be in the wrong index.

* Rename inner `callback` to not shadow the outer `callback`