### PR TITLE
Feature: Ability to debug config loader strategies

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1,6 +1,6 @@
 var deepCopy = require('lodash').deepCopy;
 
-function Config () {
+function Config() {
 }
 
 Config.prototype.clone = function () {

--- a/lib/ConfigLoader.js
+++ b/lib/ConfigLoader.js
@@ -22,7 +22,7 @@ function ConfigLoader(strategies, logger) {
   }
 
   if (strategies && !(strategies instanceof Array)) {
-    throw new Error("Argument 'strategies' must be an array.");
+    throw new Error('Argument \'strategies\' must be an array.');
   }
 
   for (var i = 0; i < strategies.length; i++) {
@@ -32,7 +32,7 @@ function ConfigLoader(strategies, logger) {
 
 ConfigLoader.prototype.add = function (item) {
   if (!item || typeof item.process !== 'function') {
-    throw new Error("Unable to add strategy. Strategy is either empty or missing required method 'process'.");
+    throw new Error('Unable to add strategy. Strategy is either empty or missing required method \'process\'.');
   }
 
   if (this.logger) {
@@ -47,7 +47,7 @@ ConfigLoader.prototype.add = function (item) {
 
 ConfigLoader.prototype.prepend = function (item) {
   if (!item || typeof item.process !== 'function') {
-    throw new Error("Unable to prepend strategy. Strategy is either empty or missing required method 'process'.");
+    throw new Error('Unable to prepend strategy. Strategy is either empty or missing required method \'process\'.');
   }
 
   if (this.logger) {
@@ -76,9 +76,9 @@ ConfigLoader.prototype.load = function (callback) {
   async.waterfall(tasks, function (err, result) {
     if (logger) {
       if (err) {
-        logger.debug("Error:\n" + JSON.stringify(err, null, 4) + '\n');
+        logger.debug('Error:\n' + JSON.stringify(err, null, 4) + '\n');
       } else {
-        logger.debug("Result:\n" + JSON.stringify(result, null, 4) + '\n');
+        logger.debug('Result:\n' + JSON.stringify(result, null, 4) + '\n');
       }
     }
     callback(err, result);

--- a/lib/ConfigLoader.js
+++ b/lib/ConfigLoader.js
@@ -6,13 +6,20 @@ var strategy = require('./strategy');
 var Config = require('./Config');
 
 /**
- * Config Loader
+ * ConfigLoader
  * Represents a configuration loader that loads a configuration through a list of strategies.
  *
  * @constructor
  */
-var ConfigLoader = function (strategies) {
+function ConfigLoader(strategies, logger) {
   this.strategies = [];
+
+  if (logger) {
+    if (typeof logger.debug !== 'function') {
+      throw new Error('Provided logger is required to have method debug().');
+    }
+    this.logger = logger;
+  }
 
   if (strategies && !(strategies instanceof Array)) {
     throw new Error("Argument 'strategies' must be an array.");
@@ -21,25 +28,40 @@ var ConfigLoader = function (strategies) {
   for (var i = 0; i < strategies.length; i++) {
     this.add(strategies[i]);
   }
-};
+}
 
-ConfigLoader.prototype.add = function (strategy) {
-  if (!strategy || !strategy.process) {
+ConfigLoader.prototype.add = function (item) {
+  if (!item || typeof item.process !== 'function') {
     throw new Error("Unable to add strategy. Strategy is either empty or missing required method 'process'.");
   }
 
-  this.strategies.push(strategy);
+  if (this.logger) {
+    if (typeof item.setLogger === 'function') {
+      item.setLogger(this.logger);
+    }
+    this.strategies.push(new strategy.DebugConfigStrategy(this.logger, 'Before:' + item.constructor.name));
+  }
+
+  this.strategies.push(item);
 };
 
-ConfigLoader.prototype.prepend = function (strategy) {
-  if (!strategy || !strategy.process) {
+ConfigLoader.prototype.prepend = function (item) {
+  if (!item || typeof item.process !== 'function') {
     throw new Error("Unable to prepend strategy. Strategy is either empty or missing required method 'process'.");
   }
 
-  this.strategies.unshift(strategy);
+  if (this.logger) {
+    if (typeof item.setLogger === 'function') {
+      item.setLogger(this.logger);
+    }
+    this.strategies.unshift(new strategy.DebugConfigStrategy(this.logger, 'Before:' + item.constructor.name));
+  }
+
+  this.strategies.unshift(item);
 };
 
 ConfigLoader.prototype.load = function (callback) {
+  var logger = this.logger;
   var strategies = this.strategies.slice();
 
   // Ensure that we always start out with a empty config object.
@@ -51,7 +73,16 @@ ConfigLoader.prototype.load = function (callback) {
     tasks.push(strategies[i].process.bind(strategies[i]));
   }
 
-  async.waterfall(tasks, callback);
+  async.waterfall(tasks, function (err, result) {
+    if (logger) {
+      if (err) {
+        logger.debug("Error:\n" + JSON.stringify(err, null, 4) + '\n');
+      } else {
+        logger.debug("Result:\n" + JSON.stringify(result, null, 4) + '\n');
+      }
+    }
+    callback(err, result);
+  });
 };
 
 module.exports = ConfigLoader;

--- a/lib/strategy/DebugConfigStrategy.js
+++ b/lib/strategy/DebugConfigStrategy.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/**
+ * Represents a strategy that when used dumps
+ * the config to the provided logger.
+ *
+ * @class
+ */
+function DebugConfigStrategy(logger, section) {
+  this.logger = logger;
+  this.section = section;
+}
+
+DebugConfigStrategy.prototype.process = function (config, callback) {
+  var friendlyFormat = JSON.stringify(config, null, 4);
+  this.logger.debug(this.section + ':\n' + friendlyFormat + '\n');
+  callback(null, config);
+};
+
+module.exports = DebugConfigStrategy;

--- a/lib/strategy/index.js
+++ b/lib/strategy/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   NullConfigStrategy: require('./NullConfigStrategy'),
+  DebugConfigStrategy: require('./DebugConfigStrategy'),
   ExtendConfigStrategy: require('./ExtendConfigStrategy'),
   LoadEnvConfigStrategy: require('./LoadEnvConfigStrategy'),
   LoadFileConfigStrategy: require('./LoadFileConfigStrategy'),

--- a/test/strategy/DebugConfigStrategyTest.js
+++ b/test/strategy/DebugConfigStrategyTest.js
@@ -23,8 +23,8 @@ describe('DebugConfigStrategy', function () {
   var loggedTestMessages = [];
 
   before(function () {
-    testSection = 'test';
-    testConfig = { abc: '123' };
+    testSection = '5c774a9e-72b2-4784-9729-3add5341fd39';
+    testConfig = { abc: '5e2bf333-deac-490a-bfb2-f7d83f2748e1' };
 
     testListener = function onMessageLogged(type, message) {
       loggedTestMessages.push({ type: type, message: message });
@@ -47,7 +47,7 @@ describe('DebugConfigStrategy', function () {
 
     it('should log debug message', function () {
       assert.equal(loggedTestMessages.length, 1);
-      assert.deepEqual(loggedTestMessages[0], { type: 'debug', message: 'test:\n' + JSON.stringify(testConfig, null, 4) + '\n' });
+      assert.deepEqual(loggedTestMessages[0], { type: 'debug', message: testSection + ':\n' + JSON.stringify(testConfig, null, 4) + '\n' });
     });
 
     it('should call callback with provided config', function () {

--- a/test/strategy/DebugConfigStrategyTest.js
+++ b/test/strategy/DebugConfigStrategyTest.js
@@ -1,0 +1,54 @@
+'use strict';
+
+var common = require('../common');
+var assert = common.assert;
+
+var strategy = require('../../lib/strategy');
+var DebugConfigStrategy = strategy.DebugConfigStrategy;
+
+function MockLogger(listener) {
+  this.listener = listener;
+}
+
+MockLogger.prototype.debug = function (message) {
+  this.listener('debug', message);
+};
+
+describe('DebugConfigStrategy', function () {
+  var mockLogger;
+  var testSection;
+  var testConfig;
+  var testStrategy;
+  var testListener;
+  var loggedTestMessages = [];
+
+  before(function () {
+    testSection = 'test';
+    testConfig = { abc: '123' };
+
+    testListener = function onMessageLogged(type, message) {
+      loggedTestMessages.push({ type: type, message: message });
+    };
+
+    mockLogger = new MockLogger(testListener);
+    testStrategy = new DebugConfigStrategy(mockLogger, testSection);
+  });
+
+  describe('when processing', function () {
+    it('should log debug message', function (done) {
+      testStrategy.process(testConfig, function (err, config) {
+        assert.equal(loggedTestMessages.length, 1);
+        assert.deepEqual(loggedTestMessages[0], { type: 'debug', message: 'test:\n' + JSON.stringify(testConfig, null, 4) + '\n' });
+        done();
+      });
+    });
+
+    it('should call callback with provided config', function (done) {
+      testStrategy.process(testConfig, function (err, config) {
+        assert.notOk(err);
+        assert.deepEqual(config, testConfig);
+        done();
+      });
+    });
+  })
+});

--- a/test/strategy/DebugConfigStrategyTest.js
+++ b/test/strategy/DebugConfigStrategyTest.js
@@ -34,21 +34,24 @@ describe('DebugConfigStrategy', function () {
     testStrategy = new DebugConfigStrategy(mockLogger, testSection);
   });
 
-  describe('when processing', function () {
-    it('should log debug message', function (done) {
+  describe('.process(config, callback)', function () {
+    var returnedConfig;
+
+    beforeEach(function (done) {
       testStrategy.process(testConfig, function (err, config) {
-        assert.equal(loggedTestMessages.length, 1);
-        assert.deepEqual(loggedTestMessages[0], { type: 'debug', message: 'test:\n' + JSON.stringify(testConfig, null, 4) + '\n' });
-        done();
+        returnedConfig = config;
+
+        done(err);
       });
     });
 
-    it('should call callback with provided config', function (done) {
-      testStrategy.process(testConfig, function (err, config) {
-        assert.notOk(err);
-        assert.deepEqual(config, testConfig);
-        done();
-      });
+    it('should log debug message', function () {
+      assert.equal(loggedTestMessages.length, 1);
+      assert.deepEqual(loggedTestMessages[0], { type: 'debug', message: 'test:\n' + JSON.stringify(testConfig, null, 4) + '\n' });
     });
-  })
+
+    it('should call callback with provided config', function () {
+      assert.deepEqual(returnedConfig, testConfig);
+    });
+  });
 });


### PR DESCRIPTION
Add the ability to provide a logger and have configuration between each strategy (when processing) outputted to the logger.

#### How to verify

1. Check out this feature branch.
2. Run `$ npm link`.
3. Create a new project directory.
4. In that directory, create a new file called `config-test.js` and put the content of [this gist](https://gist.github.com/typerandom/cb0bed76adcf052b84f8) in it.
5. Link our new project to our feature branch by executing `$ npm link stormpath-config`.
6. Execute `$ node config-test.js`.
7. Check the console.

#### Expected

The following console output:

```term
Before:FooStrategy:
{}

Result:
{
    "abc": "123"
}

Config loaded with null { abc: '123' }
```