### PR TITLE
Fix: Empty stormpath.apikey file clears configuration

### DIFF
--- a/lib/strategy/LoadAPIKeyConfigStrategy.js
+++ b/lib/strategy/LoadAPIKeyConfigStrategy.js
@@ -58,7 +58,7 @@ LoadAPIKeyConfigStrategy.prototype.process = function (config, callback) {
         // If we don't require the file to exist and if the key
         // file is empty, then just ignore it.
         if (!mustExist && Object.keys(result).length === 0) {
-          return callback(null, {});
+          return callback(null, config);
         }
 
         var apiKeyId = result['apiKey.id'];

--- a/test/strategy/EnrichClientFromRemoteConfigStrategyTest.js
+++ b/test/strategy/EnrichClientFromRemoteConfigStrategyTest.js
@@ -45,7 +45,13 @@ describe('EnrichClientFromRemoteConfigStrategy', function () {
 
   before(function (done) {
     client = new stormpath.Client({
-      skipRemoteConfig: true
+      skipRemoteConfig: true,
+      client: {
+        apiKey: {
+          id: 'abc',
+          secret: 'def'
+        }
+      }
     });
 
     testStrategy = new EnrichClientFromRemoteConfigStrategy(function () {

--- a/test/strategy/EnrichIntegrationFromRemoteConfigStrategyTest.js
+++ b/test/strategy/EnrichIntegrationFromRemoteConfigStrategyTest.js
@@ -81,7 +81,13 @@ describe('EnrichIntegrationFromRemoteConfigStrategy', function () {
 
   before(function (done) {
     client = new stormpath.Client({
-      skipRemoteConfig: true
+      skipRemoteConfig: true,
+      client: {
+        apiKey: {
+          id: 'abc',
+          secret: 'def'
+        }
+      }
     });
 
     testStrategy = new EnrichIntegrationFromRemoteConfigStrategy(function () {

--- a/test/strategy/LoadAPIKeyConfigStrategyTest.js
+++ b/test/strategy/LoadAPIKeyConfigStrategyTest.js
@@ -124,7 +124,7 @@ describe('LoadAPIKeyConfigStrategy', function () {
 
     strategy.process(_.cloneDeep(testConfig), function (err, config) {
       assert.isNull(err);
-      assert.deepEqual(config, {});
+      assert.deepEqual(config, testConfig);
       done();
     });
   });


### PR DESCRIPTION
Fixes an invalid callback that previously caused an empty `apiKey.properties` file to "clear" all of the previously loaded configuration.

#### How to verify

1. Checkout the this branch.
2. Make it available for linking `$ npm link`.
3. Checkout the Node SDK master.
4. Make it available for linking `$ npm link`.
5. Make it link to this branch `$ npm link stormpath-config`.
6. Create an empty `~/.stormpath/apiKey.properties` file.
7. Create a new project directory.
8. In this directory, create a new file called `app.js` and put the content of [this gist](https://gist.github.com/typerandom/1021c707735323dbb5fc) in it.
9. Make it link to the Node SDK (`$ npm link stormpath`).
10. Run the application `$ node app.js`.

#### Expected

Console output showing `SDK is ready!`.

Fixes #26.