### PR TITLE
Fix: Issue with loading apiKey.properties from homepath

### DIFF
--- a/lib/strategy/LoadAPIKeyConfigStrategy.js
+++ b/lib/strategy/LoadAPIKeyConfigStrategy.js
@@ -27,7 +27,7 @@ LoadAPIKeyConfigStrategy.prototype.process = function (config, callback) {
     return callback(null, config);
   }
 
-  fs.exists(this.filePath, function (exist) {
+  fs.exists(filePath, function (exist) {
     if (!exist) {
       if (mustExist) {
         callback(new Error('Client API key file not found: ' + filePath));


### PR DESCRIPTION
Fixes a issue where an API key wouldn't be loaded correctly from a home path.

#### How to verify

1. Checkout this branch.
2. Execute `$ npm link` to make it available as a link.
3. Create an empty test project folder (e.g. `stormpath-config-test`) and `$ cd` into it.
4. Execute `$ npm init --yes`.
5. Execute `$ npm link stormpath-config` so that we link to our `stormpath-config` master branch.
6. Create a new file called `app.js` and put the contents of [this gist](
https://gist.github.com/typerandom/8643f058b2033a288efe) in it.
7. Create an `apiKey.properties` with [the following content](https://gist.github.com/typerandom/2f132335a1510e3ee738) and put it in the `~/.stormpath/` directory.
8. Run `$ node app.js`.

#### Expected

Console outputs:

```term
null { bob: 123, client: { apiKey: { id: 'abc', secret: 'def' } } }
```

Fixes #28.