### PR TITLE
Implement the web.socialProviders.callbackRoot config option

### DIFF
--- a/lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js
+++ b/lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js
@@ -65,6 +65,12 @@ EnrichIntegrationFromRemoteConfigStrategy.prototype._enrichWithSocialProviders =
       config.socialProviders = {};
     }
 
+    if (!config.web.socialProviders) {
+      config.web.socialProviders = {};
+    }
+
+    var callbackRoot = config.web.socialProviders.callbackRoot || '/callbacks';
+
     mappings.each(function (mapping, next) {
       mapping.getAccountStore(function (err, accountStore) {
         if (err) {
@@ -94,7 +100,7 @@ EnrichIntegrationFromRemoteConfigStrategy.prototype._enrichWithSocialProviders =
               }
 
               if (!localProvider.callbackUri) {
-                localProvider.callbackUri = '/callbacks/' + remoteProvider.providerId;
+                localProvider.callbackUri = callbackRoot + '/' + remoteProvider.providerId;
               }
 
               extend(remoteProvider, { enabled: true });


### PR DESCRIPTION
This PR implements the `web.socialProviders.callbackRoot` config option.

Fixes #32.

### Discussion

See the discussion on https://github.com/stormpath/express-stormpath/pull/318 regarding preceding `/` and `config.web.socialProviders` vs. `config.socialProviders`.

### How to verify

1. **Checkout `master`**
2. Run `npm link` and then `npm link stormpath-config` in your `express-stormpath` project
3. Then link `express-stormpath` to your sample express app
4. Add a `console.log` to `stormpath-node-config/lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js`, so it looks like this:

  ```javascript
if (!localProvider.callbackUri) {
  localProvider.callbackUri = callbackRoot + '/' + remoteProvider.providerId;
  console.log(localProvider.callbackUri);
}
```

5. Start your sample app
6. Verify that you get this in your terminal (depending on what social providers you have):

  ```bash
/callbacks/linkedin
/callbacks/facebook
/callbacks/github
/callbacks/google
```

7. **Now checkout this branch**
8. Add the same `console.log` as in step 4
9. Run your app again and verify the same result
10. Now edit your config and set `web.socialProviders.callbackRoot` to `"/cb"`
11. Run your app again an verify you get this result:

  ```bash
/cb/linkedin
/cb/facebook
/cb/github
/cb/google
```

12. See my discussion before merging
