### PR TITLE
Fix array issue with web.produces

### DIFF
--- a/lib/strategy/ExtendConfigStrategy.js
+++ b/lib/strategy/ExtendConfigStrategy.js
@@ -20,6 +20,11 @@ ExtendConfigStrategy.prototype.process = function (config, callback) {
     config.cacheOptions.client = this.extendWith.cacheOptions.client;
   }
 
+  // TODO: Fix hack. Same as above.
+  if(this.extendWith && this.extendWith.web && this.extendWith.web.produces){
+    config.web.produces = this.extendWith.web.produces;
+  }
+
   callback(null, config);
 };
 


### PR DESCRIPTION
Adds a hack to fix the array issue with web.produces.

#### How to verify

1. Checkout this branch.
2. Run `$ npm link`.
3. Checkout and link the `stormpath` and `express-stormpath` stormpath modules with `stormpath-config`.
4. Do steps 2-16 of this PR https://github.com/stormpath/express-stormpath/pull/313.

Fixes #34.