### PR TITLE
Add validation to ensure that web.spa.enabled isn't set without a web.spa.view

### DIFF
--- a/lib/strategy/ValidateClientConfigStrategy.js
+++ b/lib/strategy/ValidateClientConfigStrategy.js
@@ -43,6 +43,12 @@ ValidateClientConfigStrategy.prototype.process = function (config, callback) {
     return newError("Application HREF '" + application.href + "' is not a valid Stormpath Application HREF.");
   }
 
+  var web = config.web;
+
+  if (web.spa && web.spa.enabled && web.spa.view === null) {
+    return newError("SPA mode is enabled but web.spa.view isn't set. This needs to be the absolute path to the file that you want to serve.");
+  }
+
   callback(null, config);
 };
 


### PR DESCRIPTION
Adds validation so that we ensure that `web.spa.enabled` isn't set without a `web.spa.view`.

#### Discussion

What do you think about the error message? Is it descriptive enough?

#### How to verify

1. Checkout this branch.
2. Run `$ npm link`.
3. Checkout and link the `stormpath` and `express-stormpath` stormpath modules with `stormpath-config`.
4. Clone [express-stormpath-sample-project](https://github.com/stormpath/express-stormpath-sample-project).
5. Use `npm link` and `npm link express-stormpath` to link the library to the example project.
6. Open up `app.js` and set `web.spa.enabled` to `true`.
7. Start the server.
8. Verify that the `SPA mode is enabled but web.spa.view isn't set. This needs to be the absolute path to the page that you want to serve.` console error error is shown.
9. Open up `app.js` and set `web.spa.view` to `abc`.
10. Start the server.
11. Verify that that no console error is being shown.
9. Open up `app.js` and set `web.spa.enabled` to `false` and `web.spa.view` to `null`.
10. Start the server.
11. Verify that that no console error is being shown.

Fixes #36.