### PR TITLE
Implement stormpath.web.social config options

### DIFF
--- a/lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js
+++ b/lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js
@@ -61,8 +61,8 @@ EnrichIntegrationFromRemoteConfigStrategy.prototype._enrichWithSocialProviders =
       return callback(err);
     }
 
-    if (!config.socialProviders) {
-      config.socialProviders = {};
+    if (!config.web.social) {
+      config.web.social = {};
     }
 
     mappings.each(function (mapping, next) {
@@ -87,14 +87,14 @@ EnrichIntegrationFromRemoteConfigStrategy.prototype._enrichWithSocialProviders =
               delete remoteProvider.createdAt;
               delete remoteProvider.updatedAt;
 
-              var localProvider = config.socialProviders[providerId];
+              var localProvider = config.web.social[providerId];
 
               if (!localProvider) {
-                localProvider = config.socialProviders[providerId] = {};
+                localProvider = config.web.social[providerId] = {};
               }
 
-              if (!localProvider.callbackUri) {
-                localProvider.callbackUri = '/callbacks/' + remoteProvider.providerId;
+              if (!localProvider.uri) {
+                localProvider.uri = '/callbacks/' + remoteProvider.providerId;
               }
 
               extend(remoteProvider, { enabled: true });

--- a/test/strategy/EnrichIntegrationFromRemoteConfigStrategyTest.js
+++ b/test/strategy/EnrichIntegrationFromRemoteConfigStrategyTest.js
@@ -194,7 +194,7 @@ describe('EnrichIntegrationFromRemoteConfigStrategy', function () {
       });
     });
 
-    it('should set the socialProviders property on the configuration', function (done) {
+    it('should set the web.social property on the configuration', function (done) {
       var mockOAuthPolicy = {};
       var mockAccountStoreMappings = new Collection({ size: 1 });
       var mockApplication = makeMockApplication(mockOAuthPolicy, mockAccountStoreMappings);
@@ -202,7 +202,7 @@ describe('EnrichIntegrationFromRemoteConfigStrategy', function () {
 
       testStrategy.process(mockConfig, function (err, result) {
         assert.isNull(err);
-        assert.isDefined(result.socialProviders);
+        assert.isDefined(result.web.social);
         done();
       });
     });


### PR DESCRIPTION
This PR implements the [`stormpath.web.social`](https://github.com/stormpath/stormpath-framework-spec/blob/master/social.md#implementing-page-based-workflows) config options according to the spec.

* It renames `config.socialProviders` to `config.web.social`
* It renames `.callbackUri` to `.uri`

Fixes #32.

### Notes

I think we missed a thing in the spec. This is what [social.md](https://github.com/stormpath/stormpath-framework-spec/blob/master/social.md#implementing-page-based-workflows) defines how the callbacks should be built:

> `<stormpath.web.social.[providerId].uri>/<providerId>`

But in [web-config.yaml](https://github.com/stormpath/stormpath-framework-spec/blob/master/web-config.yaml#L196-L207) the URIs are hardcoded to e.g. `/callbacks/facebook`. If we would build the URI according to the spec, it would look like this:

> /callbacks/facebook/facebook

I went with only using the URI from the config and not appending the provider id.

### How to verify

1. **Checkout `master`**
2. Run `npm link` and then `npm link stormpath-config` in your `express-stormpath` project
3. Then link `express-stormpath` to your sample express app
4. Add a `console.log` to `stormpath-node-config/lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js` on line `111` so it looks like this:

  ```javascript
}, function(err) {
    console.log(config.socialProviders);
    callback(err, application);
});
```

5. Start your sample app
6. Verify that you get something like this in your terminal (depending on what social providers you have):

  ```bash
Initializing Stormpath
{ facebook:
   { callbackUri: '/callbacks/facebook',
     modifiedAt: '2016-01-13T16:10:03.138Z',
     clientId: '507166112781191',
     clientSecret: '...',
     providerId: 'facebook',
     enabled: true },
  google:
   { callbackUri: '/callbacks/google',
     modifiedAt: '2015-10-15T07:59:49.014Z',
     clientId: '258595809528-rcnc35ersk1i48q03c4kmcalqh8fr3ep.apps.googleusercontent.com',
     clientSecret: '...',
     providerId: 'google',
     redirectUri: 'postmessage',
     enabled: true } }
Stormpath Ready
```

7. **Now checkout this branch**
8. Add a `console.log` statement on line `111` again so it looks like this:

  ```javascript
}, function(err) {
    console.log(config.web.social);
    callback(err, application);
});
```

9. Run your app again and verify the same result
10. Now edit your config (for example in `express-stormpath`) to this:

  ```yaml
web:
  social:
    google:
      uri: /cb/google
    facebook:
      uri: /cb/fb
      scope: email
```

11. Run your app again and verify you get something like this (look for `uri` and `scope`):

  ```bash
Initializing Stormpath
{ google:
   { uri: '/cb/google',
     modifiedAt: '2015-10-15T07:59:49.014Z',
     clientId: '258595809528-rcnc35ersk1i48q03c4kmcalqh8fr3ep.apps.googleusercontent.com',
     clientSecret: '...',
     providerId: 'google',
     redirectUri: 'postmessage',
     enabled: true },
  facebook:
   { uri: '/cb/fb',
     scope: 'email',
     modifiedAt: '2016-01-13T16:10:03.138Z',
     clientId: '507166112781191',
     clientSecret: '...',
     providerId: 'facebook',
     enabled: true } }
Stormpath Ready
```