### PR TITLE
Fix fieldOrder extend issues for web.login and web.register

### DIFF
--- a/lib/strategy/ExtendConfigStrategy.js
+++ b/lib/strategy/ExtendConfigStrategy.js
@@ -16,13 +16,30 @@ ExtendConfigStrategy.prototype.process = function (config, callback) {
 
   // TODO: FIX HACK! Resolve this in a more generic/re-usable way, perhaps
   // using a different object extension library.
-  if(this.extendWith && this.extendWith.cacheOptions && this.extendWith.cacheOptions.client){
-    config.cacheOptions.client = this.extendWith.cacheOptions.client;
-  }
+  if (this.extendWith) {
+    var extendWith = this.extendWith;
 
-  // TODO: Fix hack. Same as above.
-  if(this.extendWith && this.extendWith.web && this.extendWith.web.produces){
-    config.web.produces = this.extendWith.web.produces;
+    if(extendWith.cacheOptions && extendWith.cacheOptions.client){
+      config.cacheOptions.client = extendWith.cacheOptions.client;
+    }
+
+    // TODO: HACK! Fix issue with extend library extending arrays
+    // instead of overwriting them.
+    if (extendWith.web) {
+      var web = extendWith.web;
+
+      if (web.produces) {
+        config.web.produces = web.produces;
+      }
+
+      if (web.login && web.login.form && web.login.form.fieldOrder) {
+        config.web.login.form.fieldOrder = web.login.form.fieldOrder;
+      }
+
+      if (web.register && web.register.form && web.register.form.fieldOrder) {
+        config.web.register.form.fieldOrder = web.register.form.fieldOrder;
+      }
+    }
   }
 
   callback(null, config);

--- a/test/strategy/ExtendConfigStrategyTest.js
+++ b/test/strategy/ExtendConfigStrategyTest.js
@@ -83,28 +83,109 @@ describe('ExtendConfigStrategy', function () {
     });
   });
 
-  it('should preserve prototype references', function() {
-    var baseConfig = {
-      foo: 'bar',
-      cacheOptions: { }
-    };
+  describe('extension hacks', function () {
+    it('should preserve the cacheOptions.client object reference', function() {
+      var baseConfig = {
+        foo: 'bar',
+        cacheOptions: { }
+      };
 
-    function MockCacheClient(){
-      return this;
-    }
-    MockCacheClient.prototype.get = function get() { };
-    MockCacheClient.prototype.set = function set() { };
-    var extendConfig = {
-      cacheOptions: {
-        client: new MockCacheClient()
+      function MockCacheClient(){
+        return this;
       }
-    };
-    var strategy = new ExtendConfigStrategy(extendConfig);
+      MockCacheClient.prototype.get = function get() { };
+      MockCacheClient.prototype.set = function set() { };
+      var extendConfig = {
+        cacheOptions: {
+          client: new MockCacheClient()
+        }
+      };
+      var strategy = new ExtendConfigStrategy(extendConfig);
 
-    strategy.process(baseConfig, function(err, newConfig){
-      assert.isNull(err);
-      assert.equal(newConfig.foo, baseConfig.foo);
-      assert.equal(newConfig.cacheOptions.client.get, extendConfig.cacheOptions.client.get);
+      strategy.process(baseConfig, function(err, newConfig){
+        assert.isNull(err);
+        assert.equal(newConfig.foo, baseConfig.foo);
+        assert.equal(newConfig.cacheOptions.client.get, extendConfig.cacheOptions.client.get);
+      });
+    });
+
+    it('should overwrite the web.produces array', function () {
+      var baseConfig = {
+        web: {
+          produces: ['df9d24dd-59b2-4485-a1ae-18b3b04e71fd', 'fa845bd0-541c-4062-b52c-6757b372d8e2', '414c77f8-45d6-413d-aa49-122ddb62c82c']
+        }
+      };
+
+      var extendConfig = {
+        web: {
+          produces: ['81b52001-384f-4944-adc8-56cc81c6fa62']
+        }
+      };
+
+      var strategy = new ExtendConfigStrategy(extendConfig);
+
+      strategy.process(baseConfig, function(err, newConfig){
+        assert.isNull(err);
+        assert.deepEqual(newConfig.web.produces, extendConfig.web.produces);
+      });
+    });
+
+    it('should overwrite the web.login.form.fieldOrder array', function () {
+      var baseConfig = {
+        web: {
+          login: {
+            form: {
+              fieldOrder: ['53b83ca6-b34c-41ab-95da-5d6df830b411', '9488945a-bb61-4ee4-92ab-810f0238f67e', 'c1e11faf-0928-4cec-8b84-48af0ff006a1']
+            }
+          }
+        }
+      };
+
+      var extendConfig = {
+        web: {
+          login: {
+            form: {
+              fieldOrder: ['f066405c-4232-41d1-a63d-e99a11b3e894']
+            }
+          }
+        }
+      };
+
+      var strategy = new ExtendConfigStrategy(extendConfig);
+
+      strategy.process(baseConfig, function(err, newConfig){
+        assert.isNull(err);
+        assert.deepEqual(newConfig.web.login.form.fieldOrder, extendConfig.web.login.form.fieldOrder);
+      });
+    });
+
+    it('should overwrite the web.register.form.fieldOrder array', function () {
+      var baseConfig = {
+        web: {
+          register: {
+            form: {
+              fieldOrder: ['cabacd56-d996-49e1-bd3c-2fbac565473d', 'ccfb9bed-f2e6-4ca8-a854-ce0bae55c941', '7106bfd1-df64-40c1-b379-cd18dde9cb43']
+            }
+          }
+        }
+      };
+
+      var extendConfig = {
+        web: {
+          register: {
+            form: {
+              fieldOrder: ['7d360fe6-0708-470a-857e-46170c84dbe0']
+            }
+          }
+        }
+      };
+
+      var strategy = new ExtendConfigStrategy(extendConfig);
+
+      strategy.process(baseConfig, function(err, newConfig){
+        assert.isNull(err);
+        assert.deepEqual(newConfig.web.register.form.fieldOrder, extendConfig.web.register.form.fieldOrder);
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes fieldOrder extension issues for the `web.login.form` and `web.register.form` properties. Previously the arrays were merged, now they are replaced (as expected).

##### How to verify

1. Link this branch with `express-stormpath`.
2. Using a `express-stormpath` sample application, change the `web.login.form.fieldOrder` and `web.register.form.fieldOrder` config.
3. Run the application and verify that the fields are set as expected.