### PR TITLE
Fix LoadFileConfigStrategy issue with expanded path not being used

### DIFF
--- a/lib/strategy/LoadFileConfigStrategy.js
+++ b/lib/strategy/LoadFileConfigStrategy.js
@@ -21,39 +21,40 @@ LoadFileConfigStrategy.prototype.process = function (config, callback) {
   var outerScope = this;
 
   var mustExist = this.mustExist;
-  var filePath = expandHomeDir(this.filePath);
+  var originalFilePath = this.filePath;
+  var expandedFilePath = expandHomeDir(originalFilePath);
 
   // In case we don't have a home path but specified a '~' in our path...
-  if (filePath === false) {
+  if (expandedFilePath === false) {
     if (mustExist) {
-      return callback(new Error("Unable to load '" + this.filePath + "'. Environment home not set."));
+      return callback(new Error("Unable to load '" + originalFilePath + "'. Environment home not set."));
     }
     return callback(null, config);
   }
 
-  var extension = path.extname(filePath).substring(1);
+  var extension = path.extname(expandedFilePath).substring(1);
   var parser = parsers[extension];
 
   if (!parser) {
-    return callback(new Error("Unable to load file '" + filePath + "'. Extension '" + extension + "' not supported."));
+    return callback(new Error("Unable to load file '" + originalFilePath + "'. Extension '" + extension + "' not supported."));
   }
 
-  fs.exists(this.filePath, function (exists) {
+  fs.exists(expandedFilePath, function (exists) {
     if (!exists) {
       if (mustExist) {
-        callback(new Error("Config file '" + filePath + "' doesn't exist."));
+        callback(new Error("Config file '" + originalFilePath + "' doesn't exist."));
       } else {
         callback(null, config);
       }
     } else {
-      fs.readFile(filePath, { encoding: outerScope.encoding }, function (err, result) {
+      fs.readFile(expandedFilePath, { encoding: outerScope.encoding }, function (err, result) {
         if (err) {
           return callback(err);
         }
 
         parser(result, function (err, data) {
           if (err) {
-            return callback(new Error("Error parsing file '" + filePath + "'.\nDetails: " + err));
+            return callback(new Error("Error parsing file '" + expandedFilePath + "'.\nDetails: " + err));
           }
 
           if (data) {


### PR DESCRIPTION
Fixes the LoadFileConfigStrategy so that it uses the correct expanded path. Previously it was expanding the path, but never using it. Which worked fine for *nix, but probably not that well for Windows.

#### How to verify

Link this into the `stormpath` and `express-stormpath` libraries and then validate that you can run a `express-stormpath` server with configuration loaded from your home and application directory.

Fixes #44