### PR TITLE
Allow user-provided config to disable email verification, password reset

### DIFF
--- a/lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js
+++ b/lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js
@@ -174,18 +174,19 @@ EnrichIntegrationFromRemoteConfigStrategy.prototype._enrichWithDirectoryPolicies
   // Enrich config with with directory policies.
   client.getDirectory(directoryHref, { expand: 'passwordPolicy,accountCreationPolicy' }, stopIfError(function (directory) {
     var resetEmailStatusEnabled = isEnabled(directory.passwordPolicy.resetEmailStatus);
+    var verificationEmailStatusEnabled = isEnabled(directory.accountCreationPolicy.verificationEmailStatus);
 
     // Enrich config with account policies.
     extend(config, {
       web: {
         forgotPassword: {
-          enabled: resetEmailStatusEnabled
+          enabled: config.web.forgotPassword.enabled === false ? false : resetEmailStatusEnabled
         },
         changePassword: {
-          enabled: resetEmailStatusEnabled
+          enabled: config.web.changePassword.enabled === false ? false : resetEmailStatusEnabled
         },
         verifyEmail: {
-          enabled: isEnabled(directory.accountCreationPolicy.verificationEmailStatus)
+          enabled: config.web.verifyEmail.enabled === false ? false : verificationEmailStatusEnabled
         }
       }
     });

--- a/test/strategy/EnrichIntegrationFromRemoteConfigStrategyTest.js
+++ b/test/strategy/EnrichIntegrationFromRemoteConfigStrategyTest.js
@@ -208,7 +208,7 @@ describe('EnrichIntegrationFromRemoteConfigStrategy', function () {
     });
   });
 
-  describe('_enrichWithDirectoryPolicies method', function () {
+  describe('when parsing the directory workflow statuses', function () {
     var enrichWithDirectoryPolicies;
     var mockConfig;
 
@@ -227,29 +227,57 @@ describe('EnrichIntegrationFromRemoteConfigStrategy', function () {
       sandbox.stub(policy, 'getStrength').yields(null, {});
     });
 
-    describe('directory.passwordPolicy.resetEmailStatus property', function () {
+    describe('the password policy', function () {
       describe('when "ENABLED"', function () {
         beforeEach(function () {
           mockDirectory.passwordPolicy.resetEmailStatus = 'ENABLED';
         });
 
-        it('should set config.web.forgotPassword.enabled to true', function (done) {
-          mockConfig.web.forgotPassword.enabled = false;
+        describe('and config.web.forgotPassword.enabled is false', function () {
+          it('should leave config.web.forgotPassword.enabled as false', function (done) {
+            mockConfig.web.forgotPassword.enabled = false;
 
-          enrichWithDirectoryPolicies(client, mockConfig, mockDirectory.href, function () {
-            assert.equal(mockConfig.web.forgotPassword.enabled, true);
-            done();
+            enrichWithDirectoryPolicies(client, mockConfig, mockDirectory.href, function () {
+              assert.equal(mockConfig.web.forgotPassword.enabled, false);
+              done();
+            });
           });
         });
 
-        it('should set config.web.changePassword.enabled to true', function (done) {
-          mockConfig.web.changePassword.enabled = false;
+        describe('and config.web.forgotPassword.enabled is undefined', function () {
+          it('should set config.web.forgotPassword.enabled to true', function (done) {
+            mockConfig.web.forgotPassword.enabled = undefined;
 
-          enrichWithDirectoryPolicies(client, mockConfig, mockDirectory.href, function () {
-            assert.equal(mockConfig.web.changePassword.enabled, true);
-            done();
+            enrichWithDirectoryPolicies(client, mockConfig, mockDirectory.href, function () {
+              assert.equal(mockConfig.web.forgotPassword.enabled, true);
+              done();
+            });
           });
         });
+
+        describe('and config.web.changePassword.enabled is false', function () {
+          it('should leave config.web.changePassword.enabled as false', function (done) {
+            mockConfig.web.changePassword.enabled = false;
+
+            enrichWithDirectoryPolicies(client, mockConfig, mockDirectory.href, function () {
+              assert.equal(mockConfig.web.changePassword.enabled, false);
+              done();
+            });
+          });
+        });
+
+        describe('and config.web.changePassword.enabled is undefined', function () {
+          it('should set config.web.changePassword.enabled to true', function (done) {
+            mockConfig.web.changePassword.enabled = undefined;
+
+            enrichWithDirectoryPolicies(client, mockConfig, mockDirectory.href, function () {
+              assert.equal(mockConfig.web.changePassword.enabled, true);
+              done();
+            });
+          });
+        });
+
+
       });
 
       describe('when undefined', function () {
@@ -276,5 +304,37 @@ describe('EnrichIntegrationFromRemoteConfigStrategy', function () {
         });
       });
     });
+
+    describe('the email verification policy', function(){
+      describe('when ENABLED', function(){
+        beforeEach(function () {
+          mockDirectory.accountCreationPolicy.verificationEmailStatus = 'ENABLED';
+        });
+
+        describe('and config.web.verifyEmail.enabled is false', function () {
+          it('should leave config.web.verifyEmail.enabled as false', function (done) {
+            mockConfig.web.verifyEmail.enabled = false;
+
+            enrichWithDirectoryPolicies(client, mockConfig, mockDirectory.href, function () {
+              assert.equal(mockConfig.web.verifyEmail.enabled, false);
+              done();
+            });
+          });
+        });
+
+        describe('and config.web.verifyEmail.enabled is undefined', function () {
+          it('should set config.web.verifyEmail.enabled to true', function (done) {
+            mockConfig.web.verifyEmail.enabled = undefined;
+
+            enrichWithDirectoryPolicies(client, mockConfig, mockDirectory.href, function () {
+              assert.equal(mockConfig.web.verifyEmail.enabled, true);
+              done();
+            });
+          });
+        });
+
+      });
+    });
   });
+
 });

--- a/test/strategy/EnrichIntegrationFromRemoteConfigStrategyTest.js
+++ b/test/strategy/EnrichIntegrationFromRemoteConfigStrategyTest.js
@@ -276,8 +276,6 @@ describe('EnrichIntegrationFromRemoteConfigStrategy', function () {
             });
           });
         });
-
-
       });
 
       describe('when undefined', function () {
@@ -332,9 +330,7 @@ describe('EnrichIntegrationFromRemoteConfigStrategy', function () {
             });
           });
         });
-
       });
     });
   });
-
 });


### PR DESCRIPTION
Fixes stormpath/express-stormpath#424

To verify:

1) Clone this repo, switch to this branch, run `npm link`

2) Clone express-stormpath locally, run `npm install` and `npm link stormpath-config`

3) Clone the [express-stormpath-sample-project](https://github.com/stormpath/express-stormpath-sample-project) then run `npm install` and `npm link express-stormpath`

4) Start the server with `node server.js`, navigate to http://localhost:3000

5) You should see these links on the login page:
 * Resend Verification Email?
 * Forgot Password?

6) Shut down the server, modify server.js with this configuration:

```
app.use(stormpath.init(app, {
  expand: {
    customData: true
  },
  web: {
    forgotPassword: { enabled: false },
    verifyEmail: { enabled: false }
  }
}));
```

7) Restart the server and return to http://localhost:3000/login

8) The two links should no longer be visible