### PR TITLE
Fixes for Node version 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: false
 node_js:
   - '0.10'
-  - '0.11'
   - '0.12'
   - '4.0'
+  - '6.0'
 script: travis_retry npm run test-travis

--- a/lib/helpers/clone-extend.js
+++ b/lib/helpers/clone-extend.js
@@ -1,0 +1,256 @@
+/**
+ * The contents of this file have been taken from:
+ *
+ * https://raw.githubusercontent.com/shimondoodkin/nodejs-clone-extend/47c1cb4c7fafcc51560d53bdc6a938e5f6e82bef/index.js
+ */
+var hop = Object.prototype.hasOwnProperty;
+function replace(a, b)
+{
+ if (!b)
+ {
+  return a;
+ }
+ var key;
+ for (key in b)
+ {
+  if(hop.call(b, key))
+  {
+   a[key] = b[key];
+  }
+ }
+
+ return a;
+} exports.replace=replace;
+
+function add(a, b)
+{
+ if (!b)
+ {
+  return a;
+ }
+ var key;
+ for (key in b)
+ {
+  if(hop.call(b,key))
+  {
+   if(typeof a[key] === 'undefined' ||  a[key]===null)
+   {
+    a[key] = b[key];
+   }
+  }
+ }
+ return a;
+} exports.add=add;
+
+
+function extend(a, b, context, newobjs, aparent, aname, haveaparent) // context is anti circular references mechanism
+{
+ if (a==b){ return a;}
+ if (!b)  { return a;}
+
+ var key, clean_context=false, return_sublevel=false,b_pos;
+ if(!haveaparent){ aparent={'a':a}; aname='a'; }
+ if(!context){clean_context=true;context=[];newobjs=[];}
+ b_pos=context.indexOf(b);
+ if( b_pos==-1 ) {context.push(b);newobjs.push([aparent, aname]);} else { return newobjs[b_pos][0][ newobjs[b_pos][1] ]; }
+
+ for (key in b)
+ {
+   if(hop.call(b,key))
+   {
+   if(typeof a[key] === 'undefined')
+   {
+    if(typeof b[key] === 'object')
+    {
+     if( b[key] instanceof Array ) // http://javascript.crockford.com/remedial.html
+      {a[key] = extend([], b[key],context,newobjs,a,key,true);}
+     else if(b[key]===null)
+      {a[key] = null;}
+     else if( b[key] instanceof Date )
+      { a[key]= new b[key].constructor();a[key].setTime(b[key].getTime());  }
+     else
+      { a[key] = extend({}, b[key],context,newobjs,a,key,true); /*a[key].constructor = b[key].constructor;  a[key].prototype = b[key].prototype;*/ }
+    }
+    else
+    {  a[key] = b[key]; }
+   }
+   else if(typeof a[key] === 'object' && a[key] !== null)
+   {  a[key] = extend(a[key], b[key],context,newobjs,a,key,true); /*a[key].constructor = b[key].constructor;  a[key].prototype = b[key].prototype;*/ }
+   else
+   {  a[key] = b[key]; }
+  }
+ }
+ if(clean_context) {context=null;newobjs=null;}
+ if(!haveaparent)
+ {
+  aparent=null;
+  return a;
+ }
+ if(typeof a === 'object' && !(a instanceof Array) )
+ {
+  /*a.constructor = b.constructor;
+  a.prototype   = b.prototype*/;
+ }
+ return a;
+} exports.extend=extend;
+
+function extenduptolevel(a, b, levels, context, newobjs, aparent, aname, haveaparent)
+{
+ if (a==b){ return a;}
+ if (!b){ return a;}
+
+ var key, clean_context=false, return_sublevel=false;
+ if(!haveaparent){ aparent={'a':a}; aname='a'; }
+ if(!context){clean_context=true;context=[];newobjs=[];}
+ b_pos=context.indexOf(b);
+ if( b_pos==-1 ) {context.push(b);newobjs.push([aparent, aname]);} else { return newobjs[b_pos][0][ newobjs[b_pos][1] ]; }
+
+ for (key in b)
+ {
+  if(hop.call(b,key))
+  {
+   if(typeof a[key] === 'undefined')
+   {
+    if(typeof b[key] === 'object' && levels>0)
+    {
+     if( b[key] instanceof Array ) // http://javascript.crockford.com/remedial.html
+     { a[key] = extenduptolevel([], b[key],levels-1,context,newobjs,a,key,true); }
+     else if(b[key]===null)
+     { a[key] = null; }
+     else if( b[key] instanceof Date )
+     { a[key]= new b[key].constructor();a[key].setTime(b[key].getTime());  }
+     else
+     { a[key] = extenduptolevel({}, b[key],levels-1,context,newobjs,a,key,true); }
+    }
+    else
+    {  a[key] = b[key]; }
+   }
+   else if(typeof a[key] === 'object' && a[key] !== null && levels>0)
+   {  a[key] = extenduptolevel(a[key], b[key],levels-1,context,newobjs,a,key,true); }
+   else
+   {  a[key] = b[key]; }
+  }
+ }
+ if(clean_context) {context=null;newobjs=null;}
+
+ if(!haveaparent)
+ {
+  aparent=null;
+  return a;
+ }
+ if(typeof a === 'object' && !(a instanceof Array) )
+ {
+  /*a.constructor = b.constructor;
+  a.prototype   = b.prototype;*/
+ }
+ return a;
+} exports.extenduptolevel=extenduptolevel;
+
+function clone(obj)
+{
+ if (typeof obj === 'object')
+ {
+  if (obj ===null ) { return null; }
+  if (obj instanceof Array )
+  { return extend([], obj); }
+  else if( obj instanceof Date )
+  {
+   var t= new obj.constructor();
+   t.setTime(obj.getTime());
+   return t;
+  }
+  else
+  { return extend({}, obj); }
+ }
+ return obj;
+} exports.clone=clone;
+
+function cloneextend(obj,exteddata)
+{
+ if (typeof obj === 'object')
+ {
+  if (obj ===null ) { return null; }
+  return extend(clone(obj),exteddata);
+ }
+ return obj;
+} exports.cloneextend=cloneextend;
+
+
+function cloneuptolevel(obj,level) // clone only numlevels levels other levels leave references
+{
+ if (typeof obj === 'object')
+ {
+  if (obj ===null ) { return null; }
+  if (obj instanceof Array ) { return extenduptolevel([], obj,level); }
+  return extenduptolevel({}, obj,level);
+ }
+ return obj;
+} exports.cloneuptolevel=cloneuptolevel;
+
+function foreach(object, block, context)
+{
+ if (object)
+ {
+  if (typeof object === "object" && object instanceof Array)
+   return object.forEach(object, block, context)
+  else //if (typeof object === "object") // or (object instanceof Function)...
+  {
+   if(object)
+   for (var key in object)
+   {
+    if(hop.call(object,key))
+    {
+     if(block.call(context, object[key], key, object)===false)break;
+    }
+   }
+  }
+ }
+} exports.foreach=foreach;
+
+/*
+ hasbugs and useless, yet interesting maybe developed later for dot pathed object transformation:
+
+ {
+  'foo.bar':'bluebar',
+  'foo.color':'blue'
+ }
+
+ transforemed to
+
+ {
+  foo:
+  {
+   bar:'bluebar',
+   color:'blue'
+  }
+ }
+
+ like:
+
+ var config={};
+ cloneextend.dotpath(config,{
+  'foo.bar':'bluebar',
+  'foo.color':'blue'
+ })
+
+ //
+ function dotpath(data,dotkeys,preserve)
+ {
+      if(!preserve)preserve=false;
+      var create=!preserve;
+      if(create) if(!data) data={};
+      var keys= dotkeys.split("."),value=data;
+      for (var i=0;i<keys.length;i++)
+      {
+          if(!value[keys[i]]) //should you create one?
+          {
+              if(create)
+                  value[keys[i]]={};
+              else
+                  return undefined;
+          }
+          value = value[keys[i]];
+      }
+      return value;
+ }
+ */

--- a/lib/strategy/EnrichClientConfigStrategy.js
+++ b/lib/strategy/EnrichClientConfigStrategy.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var extend = require('cloneextend').extend;
+var extend = require('../helpers/clone-extend').extend;
 
 /**
  * Represents a strategy that enriches the API Key configuration (post loading).

--- a/lib/strategy/EnrichIntegrationConfigStrategy.js
+++ b/lib/strategy/EnrichIntegrationConfigStrategy.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var extend = require('cloneextend').extend;
+var extend = require('../helpers/clone-extend').extend;
 
 /**
  * Represents a strategy that enriches the configuration (post loading).

--- a/lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js
+++ b/lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var async = require('async');
-var extend = require('cloneextend').extend;
+var extend = require('../helpers/clone-extend').extend;
 var strings = require('../strings');
 
 /**

--- a/lib/strategy/ExtendConfigStrategy.js
+++ b/lib/strategy/ExtendConfigStrategy.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var extend = require('cloneextend').extend;
+var extend = require('../helpers/clone-extend').extend;
 
 /**
  * Represents a strategy that extends the configuration.

--- a/lib/strategy/LoadAPIKeyConfigStrategy.js
+++ b/lib/strategy/LoadAPIKeyConfigStrategy.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var fs = require('fs');
-var extend = require('cloneextend').extend;
+var extend = require('../helpers/clone-extend').extend;
 var propsParser = require('properties-parser');
 var expandHomeDir = require('../helpers/expand-home-dir');
 

--- a/lib/strategy/LoadEnvConfigStrategy.js
+++ b/lib/strategy/LoadEnvConfigStrategy.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var flat = require('flat');
-var extend = require('cloneextend').extend;
+var extend = require('../helpers/clone-extend').extend;
 
 /**
  * Represents a strategy that loads configuration variables from the environment into the configuration.

--- a/lib/strategy/LoadFileConfigStrategy.js
+++ b/lib/strategy/LoadFileConfigStrategy.js
@@ -2,7 +2,7 @@
 
 var fs = require('fs');
 var path = require('path');
-var extend = require('cloneextend').extend;
+var extend = require('../helpers/clone-extend').extend;
 var parsers = require('./../parser');
 var expandHomeDir = require('../helpers/expand-home-dir');
 

--- a/lib/strategy/ValidateClientConfigStrategy.js
+++ b/lib/strategy/ValidateClientConfigStrategy.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var extend = require('cloneextend').extend;
+var extend = require('../helpers/clone-extend').extend;
 
 /**
  * Represents a strategy that validates the configuration (post loading).

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "async": "^1.4.2",
-    "cloneextend": "0.0.3",
     "flat": "^2.0.0",
     "js-yaml": "^3.4.2",
     "lodash": "^4.0.0",

--- a/test/parser/JsonParserTest.js
+++ b/test/parser/JsonParserTest.js
@@ -36,7 +36,7 @@ describe('JsonParser', function () {
 
       assert.isTrue(!!err);
       assert.isString(err.message);
-      assert.equal(err.message, "Unexpected token ,");
+      assert.match(err.message, /Unexpected token/);
 
       done();
     });

--- a/test/strategy/LoadFileConfigStrategyTest.js
+++ b/test/strategy/LoadFileConfigStrategyTest.js
@@ -134,7 +134,7 @@ describe('LoadFileConfigStrategy', function () {
     strategy.process({}, function (err, config) {
       assert.isUndefined(config);
       assert.isNotNull(err);
-      assert.equal(err.message, "Error parsing file '" + validJsonPath + "'.\nDetails: SyntaxError: Unexpected token ,");
+      assert.match(err.message, /Unexpected token/);
       done();
     });
   });


### PR DESCRIPTION
Fixes stormpath/express-stormpath#438

@typerandom so here's the deal: the `cloneextend` module was calling `hasOwnProperty()` directly on objects, and that is brittle.  Why this became a problem in node v6 I'm not sure and I didn't dig into it.  But someone did fix this issue here, by using a more robust method for checking an object for properties:

https://github.com/shimondoodkin/nodejs-clone-extend/pull/5/files

Using that commit does solve the problem in stormpath/express-stormpath#438.  That library isn't maintained very well, e.g. master has breaking changes in it, and package.json has a bumped minor number, which isn't even in npm anyways.  As such, I'm moving the author's code into this library so that we aren't depending on a fragile library.

Other changes in this PR:

- The "JSON syntax error" message text has changed in v6, so I had to update the test assertion accordingly

- Adding node v6 to travis