### PR TITLE
Allow a request executor to be passed

### DIFF
--- a/lib/strategy/ExtendConfigStrategy.js
+++ b/lib/strategy/ExtendConfigStrategy.js
@@ -23,6 +23,10 @@ ExtendConfigStrategy.prototype.process = function (config, callback) {
       config.cacheOptions.client = extendWith.cacheOptions.client;
     }
 
+    if(extendWith.requestExecutor){
+      config.requestExecutor = extendWith.requestExecutor;
+    }
+
     // TODO: HACK! Fix issue with extend library extending arrays
     // instead of overwriting them.
     if (extendWith.web) {


### PR DESCRIPTION
This allows the developer to pass in a custom `RequestExecutor` implementation, which we do in IAMUI.