### PR TITLE
Add support for setting registration fields from account schema

### DIFF
--- a/lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js
+++ b/lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js
@@ -206,8 +206,43 @@ EnrichIntegrationFromRemoteConfigStrategy.prototype._enrichWithDirectoryPolicies
 
         config.passwordPolicy = strength;
 
-        callback(null, null);
+        callback(null, directory);
       }));
+    }));
+  }));
+};
+
+EnrichIntegrationFromRemoteConfigStrategy.prototype._enrichWithDirectoryAccountModel = function (client, config, directory, callback) {
+  if (!directory) {
+    return callback(null, null);
+  }
+
+  // Returns the callback immediately if there is an error.
+  // Continues processing if there isn't.
+  var stopIfError = function (process) {
+    return function (err, result) {
+      if (err) {
+        callback(err);
+      } else {
+        process(result);
+      }
+    }
+  };
+
+  var webConfig = config.web;
+
+  // Map the registration fields defined in the account schema.
+  directory.getAccountSchema(stopIfError(function (accountSchema) {
+    accountSchema.getFields(stopIfError(function (fields) {
+      fields.each(function (field, next) {
+        if (field.name in webConfig.register.form.fields) {
+          webConfig.register.form.fields[field.name].required = field.required;
+        }
+
+        next();
+      }, function (err) {
+        callback(err, null);
+      });
     }));
   }));
 };
@@ -228,7 +263,8 @@ EnrichIntegrationFromRemoteConfigStrategy.prototype.process = function (config, 
       this._enrichWithOAuthPolicy.bind(this),
       this._enrichWithSocialProviders.bind(this, config),
       this._resolveDirectoryHref.bind(this),
-      this._enrichWithDirectoryPolicies.bind(this, client, config)
+      this._enrichWithDirectoryPolicies.bind(this, client, config),
+      this._enrichWithDirectoryAccountModel.bind(this, client, config)
     ]);
   }
 


### PR DESCRIPTION
Adds support for setting registration fields from the account schema.

##### How to verify

Add `console.log('Setting field!', field);` after `webConfig.register.form.fields[field.name].required = field.required;` in `lib/strategy/EnrichIntegrationFromRemoteConfigStrategy.js`. Then run this branch with the `express-stormpath` test application and verify that `Setting field (field)` is written to the console for the `givenName` and `surname` fields.

##### Important

This depends on features from https://github.com/stormpath/stormpath-sdk-node/pull/534 so that PR needs to be merged before.