### PR TITLE
Support for multi-tenancy enrichment

### DIFF
--- a/lib/strategy/EnrichIntegrationConfigStrategy.js
+++ b/lib/strategy/EnrichIntegrationConfigStrategy.js
@@ -7,51 +7,22 @@ var extend = require('../helpers/clone-extend').extend;
  *
  * @class
  */
-function EnrichIntegrationConfigStrategy (userConfig) {
+function EnrichIntegrationConfigStrategy(userConfig) {
   this.userConfig = userConfig;
 }
 
 EnrichIntegrationConfigStrategy.prototype.process = function (config, callback) {
-  var webFeaturesToEnable = [];
-
-  // If a user enables a boolean configuration option named `website`, this
-  // means the user is building a website and we should automatically enable
-  // certain features in the library meant for users developing websites.  This
-  // is a simpler way of handling configuration than forcing users to specify
-  // all nested JSON configuration options themselves.
-  if (config.website) {
-    webFeaturesToEnable.push('register');
-    webFeaturesToEnable.push('login');
-    webFeaturesToEnable.push('logout');
-    webFeaturesToEnable.push('me');
-  }
-
-  // If a user enables a boolean configuration option named `api`, this means
-  // the user is building an API service, and we should automatically enable
-  // certain features in the library meant for users developing API services --
-  // namely, our OAuth2 token endpoint (/oauth/token).  This allows users
-  // building APIs to easily provision OAuth2 tokens without specifying any
-  // nested JSON configuration options.
-  if (config.api) {
-    webFeaturesToEnable.push('oauth2');
-  }
-
-  var userConfig = this.userConfig;
-
-  webFeaturesToEnable.forEach(function (feature) {
-    var webFeatures = {};
-
-    // Only turn on features that haven't already been configured by the user.
-    if (!(userConfig && userConfig.web && (feature in userConfig.web) && ('enabled' in userConfig.web[feature]))) {
-      webFeatures[feature] = {
-        enabled: true
-      };
+  // If multi-tenancy is enabled, and if there isn't a value for organizationNameKey
+  // isn't set, then force a value for it.
+  if (config.web.multiTenancy.enabled) {
+    if (config.web.register.form.fields.organizationNameKey.enabled !== false) {
+      config.web.register.form.fields.organizationNameKey.enabled = true;
     }
 
-    extend(config, {
-      web: webFeatures
-    });
-  });
+    if (config.web.login.form.fields.organizationNameKey.enabled !== false) {
+      config.web.login.form.fields.organizationNameKey.enabled = true;
+    }
+  }
 
   callback(null, config);
 };


### PR DESCRIPTION
If multi-tenancy is enabled, then this enrichment sets the organizationNameKey enabled field of the login and registration forms to true if the field is not explicitly disabled.

#### Note

This strategy was previously unused. So the old things that are no longer in use were cleaned up.